### PR TITLE
Fix evolution not causing level threshold increase bug

### DIFF
--- a/src/player/player.py
+++ b/src/player/player.py
@@ -100,6 +100,6 @@ class Player():
     def gain_experience(self, experience: int) -> None:
         self.experience += experience
         if self.experience >= self.level_threshold:
-            self._level_up()
             self._increase_level_threshold(1.2)
             self.experience = self.experience - self.level_threshold
+            self._level_up()


### PR DESCRIPTION
Fix mitosis evolution causing a skip in level up experience threshold (due to it being an exception).